### PR TITLE
Add tz support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "reqwest",
  "scraper",
  "tokio",
+ "tzdb",
 ]
 
 [[package]]
@@ -192,6 +193,12 @@ checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
 dependencies = [
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
 name = "convert_case"
@@ -1736,6 +1743,25 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec758958f2fb5069cd7fae385be95cc8eceb8cdfd270c7d14de6034f0108d99e"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "When2Meet-CLI"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "When2Meet-CLI"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Abhishek More <abhimore74@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ inquire = { version = "0.6.1", features = ["date"] }
 reqwest = { version = "0.11", features = ["json", "blocking", "multipart"] }
 scraper = "0.15.0"
 tokio = { version = "1", features = ["full"] }
+tzdb = "0.5"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Answer the prompts for:
 - Title
 - Start Time
 - End Time
+- Time Zone (optional)
 - Start Date
 - End Date
 


### PR DESCRIPTION
Adds an optional step to select time zone. Without the time zone in the form data, When2meet creates an event in UTC and does not show the time zone dropdown for individual users when they click the link to the form.

The interactive prompt will show the full list of IANA time zone names, and will default to the local system time zone. You can use up and down arrows to scroll through the list, and filter the list down to partial match by typing. The time zone prompt is optional, you can skip the step by pressing ESC and the application will revert back to the original behaviour with no time zone sent in the form data.